### PR TITLE
must use the correct language code

### DIFF
--- a/language.xml
+++ b/language.xml
@@ -6,7 +6,7 @@
  */
 -->
 <language xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/Language/package.xsd">
-    <code>sr_SP</code>
+    <code>sr_Cyrl_RS</code>
     <vendor>CommunityEngineering</vendor>
     <package>sr_SP</package>
 </language>


### PR DESCRIPTION
the acceptable codes can be found by running `bin/magento info:language:list`